### PR TITLE
use uint instead of var

### DIFF
--- a/contracts/MiniMeToken.sol
+++ b/contracts/MiniMeToken.sol
@@ -235,7 +235,7 @@ contract MiniMeToken is Controlled {
 
           // If the amount being transfered is more than the balance of the
           //  account the transfer returns false
-          var previousBalanceFrom = balanceOfAt(_from, block.number);
+          uint previousBalanceFrom = balanceOfAt(_from, block.number);
           if (previousBalanceFrom < _amount) {
               return false;
           }
@@ -251,7 +251,7 @@ contract MiniMeToken is Controlled {
 
           // Then update the balance array with the new value for the address
           //  receiving the tokens
-          var previousBalanceTo = balanceOfAt(_to, block.number);
+          uint previousBalanceTo = balanceOfAt(_to, block.number);
           require(previousBalanceTo + _amount >= previousBalanceTo); // Check for overflow
           updateValueAtNow(balances[_to], previousBalanceTo + _amount);
 

--- a/contracts/NEC.sol
+++ b/contracts/NEC.sol
@@ -39,7 +39,7 @@ contract NEC is MiniMeToken {
     function burnAndRetrieve(uint256 _tokensToBurn) returns (bool success) {
         require(burningEnabled);
 
-        var previousBalanceFrom = balanceOfAt(msg.sender, block.number);
+        uint256 previousBalanceFrom = balanceOfAt(msg.sender, block.number);
         if (previousBalanceFrom < _tokensToBurn) {
             return false;
         }


### PR DESCRIPTION
Avoid using 'var' in the code, as it infers the variable type from the right hand of the assignment. In some cases it might infer a smaller integer type than the developer might think. It is best to be explicit regarding types.