### PR TITLE
Fix 'Error: exceeds block gas limit' when running 'truffle migrate'

### DIFF
--- a/truffle.js
+++ b/truffle.js
@@ -3,7 +3,8 @@ module.exports = {
     development: {
       host: "localhost",
       port: 8545,
-      network_id: "*" // Match any network id
+      network_id: "*", // Match any network id
+      gas: 4600000
     }
   }
 };


### PR DESCRIPTION
Resolution was found on https://ethereum.stackexchange.com/questions/21262/truffle-deployment-on-test-network-says-error-exceeds-block-gas-limit.