### PR TITLE
Proposal: Update to issuance equation v2

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,12 @@ A summary of the design choices and purpose of the Nectar token is available her
 
 13th February - [NEC deployed](https://etherscan.io/tx/0x4041cf804f1628c26905e1efce969e254e195b3a5ee8951a27f7039c1af5ab06) - commit fc5e6d575830ee48f0a54449e32d9dc5992f6997
 
-13th February - [Nectar Controller 1 deployed](https://etherscan.io/tx/0x840648dc7a64e0c259f278985b78ff475b6651f040ba2a4425e3515b350407ca) - commit fc5e6d575830ee48f0a54449e32d9dc5992f6997
+13th February - [Nectar Controller v1.0.0 deployed](https://etherscan.io/tx/0x840648dc7a64e0c259f278985b78ff475b6651f040ba2a4425e3515b350407ca) - commit fc5e6d575830ee48f0a54449e32d9dc5992f6997
+
+30th March - [Nectar Controller v2.0.0 deployed](https://etherscan.io/tx/0xe8b1fda901476b8e33aede88cb0690903e433147eeb32803f05f5cbedd2f5056) -
+commit latest
+
+12th April - [upgradeContoller used to switch control to v2.0.0](https://etherscan.io/tx/0xe91489b5f9eb78a96892b29dc568b418f930176f6cd13e886cd8470ac0f33b5b)
 
 
 ## Contracts summary

--- a/contracts/Whitelist.sol
+++ b/contracts/Whitelist.sol
@@ -11,6 +11,10 @@ import "./Owned.sol";
 /// @title Whitelist contract - Only addresses which are registered as part of the market maker loyalty scheme can be whitelisted to earn and own Nectar tokens
 contract Whitelist is Owned {
 
+  function Whitelist() {
+    admins[msg.sender] = true;
+  }
+
   bool public listActive = true;
 
   // Only users who are on the whitelist
@@ -22,11 +26,36 @@ contract Whitelist is Owned {
     }
   }
 
+  // Can add people to the whitelist
+  function isAdmin(address _admin) public view returns(bool) {
+    return admins[_admin];
+  }
+
+  /// @notice The owner is able to add new admin
+  /// @param _newAdmin Address of new admin
+  function addAdmin(address _newAdmin) public onlyOwner {
+    admins[_newAdmin] = true;
+  }
+
+  /// @notice Only owner is able to remove admin
+  /// @param _admin Address of current admin
+  function removeAdmin(address _admin) public onlyOwner {
+    admins[_admin] = false;
+  }
+
   // Only authorised sources/contracts can contribute fees on behalf of makers to earn tokens
   modifier authorised () {
     require(isAuthorisedMaker[msg.sender]);
     _;
   }
+
+  modifier onlyAdmins() {
+    require(isAdmin(msg.sender));
+    _;
+  }
+
+  // These admins are able to add new users to the whitelist
+  mapping (address => bool) public admins;
 
   // This is the whitelist of users who are registered to be able to own the tokens
   mapping (address => bool) public isOnList;
@@ -37,7 +66,7 @@ contract Whitelist is Owned {
 
   /// @dev register
   /// @param newUsers - Array of users to add to the whitelist
-  function register(address[] newUsers) public onlyOwner {
+  function register(address[] newUsers) public onlyAdmins {
     for (uint i = 0; i < newUsers.length; i++) {
       isOnList[newUsers[i]] = true;
     }
@@ -45,7 +74,7 @@ contract Whitelist is Owned {
 
   /// @dev deregister
   /// @param bannedUsers - Array of users to remove from the whitelist
-  function deregister(address[] bannedUsers) public onlyOwner {
+  function deregister(address[] bannedUsers) public onlyAdmins {
     for (uint i = 0; i < bannedUsers.length; i++) {
       isOnList[bannedUsers[i]] = false;
     }

--- a/test/24month.js
+++ b/test/24month.js
@@ -50,7 +50,7 @@ contract('24 months', function(accounts) {
 // Possible monthly trade volume: 50 billion usd
 // Volume is 50 million eth
 // Assuming possible monthly fees contributable to be:
-// Makers: 25000 eth
+// Makers: 10000 eth
 // Takers: 50000 eth
 
   it('pledge eth to create tokens in month 1', async function () {

--- a/test/setup.js
+++ b/test/setup.js
@@ -26,7 +26,6 @@ contract('NEC setup', function(accounts) {
   })
 
   it('should change the Controller to the Controller Contract', async function () {
-
     await nectar.changeController(controller.address, {from: accounts[0]})
     const controllerAddress = await nectar.controller.call()
     assert.equal(controllerAddress, controller.address, 'The controller was not correctly set')


### PR DESCRIPTION
`rate = 1000 * (2 — currentSupply/originalSupply)²`

The token economics behind the NEC issuance equation needed to be tested in a real environment to help refine them. By the end of the first 30 days, and with the first issuance of new tokens to market makers on Ethfinex, a few possibilities for improvement became clear.

This has lead to the development of version 2 - 

Improvements:

- fixed number of tokens (2 billion hard cap) and issuance rate curve 
- first order equation (rate not dependent on fees collected but only total supply) —  simplicity has been found to be essential for something like this as the original equation was too difficult to understand and model for most market makers. This complexity made it less attractive to traders who want to understand it and incorporate it into their profit calculations and trading strategies
- simpler to calculate and issue new tokens, since only total supply is required for rate (this may potentially enable it to be done more frequently in the future)
- no longer any dependence on ratio of maker:taker fees in determining number of tokens created during 30 day period